### PR TITLE
fix: reflect deemix api breaking change 'move /connect to /api/connect'

### DIFF
--- a/src/Lidarr.Plugin.Deemix/Download/Clients/Deemix/DeemixProxy.cs
+++ b/src/Lidarr.Plugin.Deemix/Download/Clients/Deemix/DeemixProxy.cs
@@ -337,7 +337,7 @@ namespace NzbDrone.Core.Download.Clients.Deemix
         private DeemixConnect Connect(string baseUrl)
         {
             var requestBuilder = BuildRequest(baseUrl);
-            requestBuilder.Resource("connect");
+            requestBuilder.Resource("api/connect");
 
             var response = ProcessRequest<DeemixConnect>(requestBuilder);
 


### PR DESCRIPTION
Hi, I wanted to try new Deemix version with Lidarr and I found that breaking change:
https://gitlab.com/RemixDev/deemix-gui/-/commit/554dfcced745fc96ecea851217a9d463e83e16bd