### PR TITLE
fix: skip newReleases request to prevent deemix crash on unavailable tracks

### DIFF
--- a/src/Lidarr.Plugin.Deemix/Indexers/Deemix/Deemix.cs
+++ b/src/Lidarr.Plugin.Deemix/Indexers/Deemix/Deemix.cs
@@ -12,7 +12,6 @@ namespace NzbDrone.Core.Indexers.Deemix
     {
         public override string Name => "Deemix";
         public override string Protocol => nameof(DeemixDownloadProtocol);
-        public override bool SupportsRss => true;
         public override bool SupportsSearch => true;
         public override int PageSize => 100;
         public override TimeSpan RateLimit => new TimeSpan(0);

--- a/src/Lidarr.Plugin.Deemix/Indexers/Deemix/DeemixRequestGenerator.cs
+++ b/src/Lidarr.Plugin.Deemix/Indexers/Deemix/DeemixRequestGenerator.cs
@@ -14,14 +14,6 @@ namespace NzbDrone.Core.Indexers.Deemix
 
         public virtual IndexerPageableRequestChain GetRecentRequests()
         {
-            // The /api/newReleases endpoint in deemix crashes the deemix process
-            // when any album in the feed is unavailable on Deezer (GWAPIError:
-            // "Track unavailable on Deezer"). This unhandled Promise rejection
-            // kills the deemix Node process entirely, causing it to restart.
-            //
-            // Since Lidarr discovers releases via album search rather than the
-            // recent releases feed, returning an empty chain here has no impact
-            // on normal operation and prevents the crash during indexer testing.
             return new IndexerPageableRequestChain();
         }
 

--- a/src/Lidarr.Plugin.Deemix/Indexers/Deemix/DeemixRequestGenerator.cs
+++ b/src/Lidarr.Plugin.Deemix/Indexers/Deemix/DeemixRequestGenerator.cs
@@ -14,16 +14,15 @@ namespace NzbDrone.Core.Indexers.Deemix
 
         public virtual IndexerPageableRequestChain GetRecentRequests()
         {
-            var pageableRequests = new IndexerPageableRequestChain();
-
-            var url = $"{Settings.BaseUrl.TrimEnd('/')}/api/newReleases";
-
-            pageableRequests.Add(new[]
-            {
-                new IndexerRequest(url, HttpAccept.Json)
-            });
-
-            return pageableRequests;
+            // The /api/newReleases endpoint in deemix crashes the deemix process
+            // when any album in the feed is unavailable on Deezer (GWAPIError:
+            // "Track unavailable on Deezer"). This unhandled Promise rejection
+            // kills the deemix Node process entirely, causing it to restart.
+            //
+            // Since Lidarr discovers releases via album search rather than the
+            // recent releases feed, returning an empty chain here has no impact
+            // on normal operation and prevents the crash during indexer testing.
+            return new IndexerPageableRequestChain();
         }
 
         public IndexerPageableRequestChain GetSearchRequests(AlbumSearchCriteria searchCriteria)


### PR DESCRIPTION
## What's the problem?

When the Lidarr deemix indexer is tested or used, `GetRecentRequests()` calls `/api/newReleases` on the deemix instance. If Deezer's new releases feed contains unavailable (geoblocked?) albums, deemix throws an unhandled `GWAPIError: Track unavailable on Deezer` and crashes.

The crash loop looks like this:

```
[error] unhandledRejection: Track unavailable on Deezer
GWAPIError: Track unavailable on Deezer
    at async getAlbumDetails (.../albumSearch.js:43:20)
    at async Promise.all (index 35)
    at async handler (.../newReleases.js:32:20)
[services.d] Starting Deemix   ← crash → restart → crash again
```

This means the Lidarr indexer test always fails, and deemix keeps restarting in a loop as long as Lidarr retries.

See also the related issues: #18, #21.

## What's the fix?

`GetRecentRequests()` now returns an empty chain instead of calling `/api/newReleases`. This endpoint is only used for RSS-style "recent releases" discovery, which Lidarr doesn't rely on for its core search and download functionality, those go through `GetSearchRequests()` which is unaffected.

```csharp
public virtual IndexerPageableRequestChain GetRecentRequests()
{
    // /api/newReleases crashes deemix when the feed contains geo-blocked
    // albums (GWAPIError: Track unavailable on Deezer). Returning an empty
    // chain avoids the crash without affecting search or download functionality.
    return new IndexerPageableRequestChain();
}
```

## How was this tested?

Tested with a deemix Docker container (`ghcr.io/bambanah/deemix:latest`) and Lidarr with this plugin installed. Before the fix, clicking "Test" in the Lidarr indexer settings crashed deemix every time. After deploying the fix, deemix stayed up and albums could be searched and downloaded successfully through the indexer.

> **Related:** There is a corresponding PR on the deemix side that fixes the root cause, unavailable albums are now caught and skipped instead of crashing the process: [bambanah/deemix#287](https://github.com/bambanah/deemix/pull/287). Both fixes together make the integration fully robust.

- Fixes #18
- Fixes #21 